### PR TITLE
Allow Net::SSH::Authentication::PLATFORM to be predefined

### DIFF
--- a/lib/net/ssh/authentication/agent.rb
+++ b/lib/net/ssh/authentication/agent.rb
@@ -3,7 +3,7 @@ require 'net/ssh/errors'
 require 'net/ssh/loggable'
 
 module Net; module SSH; module Authentication
-  PLATFORM = File::ALT_SEPARATOR \
+  PLATFORM ||= File::ALT_SEPARATOR \
     ? RUBY_PLATFORM =~ /java/ ? :java_win32 : :win32 \
     : RUBY_PLATFORM =~ /java/ ? :java : :unix
 


### PR DESCRIPTION
Do not overwrite Net::SSH::Authentication::PLATFORM if it is already defined.
This addresses issues #192 and #361.
